### PR TITLE
🎨 カレンダーのスタイルの更新

### DIFF
--- a/front/src/components/CalendarBoard/index.tsx
+++ b/front/src/components/CalendarBoard/index.tsx
@@ -1,10 +1,12 @@
 import { FC } from 'react';
 
-import { ImageList } from '@mui/material';
+import { ImageList, Typography } from '@mui/material';
 
 import 'dayjs/locale/ja';
 import { CalendarContainer, gridStyle } from './styles';
+import { days as styleDays } from './styles';
 import CalendarElement from '../CalendarElement';
+import { days } from '../types';
 
 import { createCalendar } from '@/utils/calendar';
 
@@ -14,10 +16,21 @@ const CalendarBoard: FC = () => {
   return (
     <CalendarContainer>
       <ImageList style={gridStyle} cols={7} gap={0}>
-        {calendar.map((c) => (
-          <CalendarElement key={c.toISOString()}>
-            {c.format('D')}
-          </CalendarElement>
+        {days.map((d, i) => (
+          <li key={i}>
+            <Typography
+              style={styleDays}
+              color="textSecondary"
+              align="center"
+              variant="caption"
+              component="div"
+            >
+              {d}
+            </Typography>
+          </li>
+        ))}
+        {calendar.map((day) => (
+          <CalendarElement key={day.toISOString()} day={day} />
         ))}
       </ImageList>
     </CalendarContainer>

--- a/front/src/components/CalendarBoard/styles.ts
+++ b/front/src/components/CalendarBoard/styles.ts
@@ -8,3 +8,8 @@ export const gridStyle = {
   borderLeft: '1px solid #ccc',
   borderTop: '1px solid #ccc',
 };
+
+export const days = {
+  borderRight: '1px solid #ccc',
+  paddingTop: '10px',
+};

--- a/front/src/components/CalendarElement/index.tsx
+++ b/front/src/components/CalendarElement/index.tsx
@@ -1,13 +1,31 @@
-import { FC, PropsWithChildren } from 'react';
+import { FC } from 'react';
 
-import { ImageListItem } from '@mui/material';
+import { ImageListItem, Typography } from '@mui/material';
+import dayjs from 'dayjs';
 
-import { elementStyle } from './styles';
+import { dateStyle, elementStyle, todayStyle } from './styles';
 
-const CalendarElement: FC<PropsWithChildren> = ({ children }) => {
+import { isCurrentMonth, isFirstDay, isToday } from '@/utils/calendar';
+
+type Props = {
+  day: dayjs.Dayjs;
+};
+
+const CalendarElement: FC<Props> = ({ day }) => {
+  const format = isFirstDay(day) ? 'M月D日' : 'D';
+  const textColor = isCurrentMonth(day) ? 'textPrimary' : 'textSecondary';
+
   return (
     <ImageListItem style={elementStyle}>
-      <span>{children}</span>
+      <Typography
+        style={dateStyle}
+        color={textColor}
+        align="center"
+        variant="caption"
+        component="div"
+      >
+        <span style={isToday(day) ? todayStyle : {}}>{day.format(format)}</span>
+      </Typography>
     </ImageListItem>
   );
 };

--- a/front/src/components/CalendarElement/styles.ts
+++ b/front/src/components/CalendarElement/styles.ts
@@ -3,3 +3,17 @@ export const elementStyle = {
   borderBottom: '1px solid #ccc',
   height: '18vh',
 };
+
+export const dateStyle = {
+  padding: '5px 0',
+  height: '24px',
+};
+
+export const todayStyle = {
+  display: 'inline-block',
+  lineHeight: '24px',
+  width: '24px',
+  backgroundColor: '#1a73e8',
+  color: '#fff',
+  borderRadius: '50%',
+};

--- a/front/src/components/types/day.ts
+++ b/front/src/components/types/day.ts
@@ -1,0 +1,1 @@
+export const days: string[] = ['日', '月', '火', '水', '木', '金', '土'];

--- a/front/src/components/types/index.ts
+++ b/front/src/components/types/index.ts
@@ -1,0 +1,1 @@
+export * from './day';

--- a/front/src/utils/calendar.ts
+++ b/front/src/utils/calendar.ts
@@ -13,3 +13,17 @@ export const createCalendar = (count: number): dayjs.Dayjs[] => {
       return day;
     });
 };
+
+export const isCurrentMonth = (day: dayjs.Dayjs) => {
+  const today = dayjs();
+  return day.month() === today.month();
+};
+
+export const isToday = (day: dayjs.Dayjs) => {
+  const today = dayjs();
+  return day.format('YYYYMMDD') === today.format('YYYYMMDD');
+};
+
+export const isFirstDay = (day: dayjs.Dayjs) => {
+  return day.date() === 1;
+};


### PR DESCRIPTION
# 概要
カレンダーコンポーネントの見た目をアップデートした
- 曜日の追加
- 今日の日付が強調されるように
- 前月の日付を少し暗めに

# UI
<img width="1414" alt="image" src="https://github.com/PenPeen/react_calendar_app/assets/87213337/e189ecca-9ae0-4838-9cf8-e49b58e86f90">
