### PR TITLE
月を移動するためのロジック実装

### DIFF
--- a/front/src/components/CalendarBoard/index.tsx
+++ b/front/src/components/CalendarBoard/index.tsx
@@ -7,11 +7,11 @@ import { styledContainer, styledGrid, styledDays } from './styles';
 import CalendarElement from '../CalendarElement';
 import { days } from '../types';
 
-import { RootState, CalenderState } from '@/stores';
+import { RootState, CalendarState } from '@/stores';
 import { createCalendar } from '@/utils/calendar';
 
 const CalendarBoard: FC = () => {
-  const currentCalendar = useSelector<RootState, CalenderState>(
+  const currentCalendar = useSelector<RootState, CalendarState>(
     (state) => state.calendar,
   );
 

--- a/front/src/components/Navigation/index.tsx
+++ b/front/src/components/Navigation/index.tsx
@@ -3,10 +3,19 @@ import { FC } from 'react';
 import { ArrowBackIos, ArrowForwardIos } from '@mui/icons-material';
 import MenuIcon from '@mui/icons-material/Menu';
 import { IconButton, Toolbar, Typography } from '@mui/material';
+import { useDispatch } from 'react-redux';
 
 import { styledToolbar, styledTypography } from './style';
 
+import calendarSlice from '@/stores/calendar';
+
+const { setNextMonth, setPrevMonth } = calendarSlice.actions;
+
 const Navigation: FC = () => {
+  const dispatch = useDispatch();
+  const handlePrevMonth = () => dispatch(setPrevMonth());
+  const handleNextMonth = () => dispatch(setNextMonth());
+
   return (
     <>
       <Toolbar style={styledToolbar}>
@@ -27,10 +36,10 @@ const Navigation: FC = () => {
         >
           カレンダー
         </Typography>
-        <IconButton size="small">
+        <IconButton size="small" onClick={handlePrevMonth}>
           <ArrowBackIos />
         </IconButton>
-        <IconButton size="small">
+        <IconButton size="small" onClick={handleNextMonth}>
           <ArrowForwardIos />
         </IconButton>
       </Toolbar>

--- a/front/src/stores/calendar.ts
+++ b/front/src/stores/calendar.ts
@@ -1,24 +1,25 @@
-import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
 import dayjs from 'dayjs';
 
-export interface CalenderState {
+import { formatMonth, ShiftedMonth } from '@/utils/calendar';
+
+export interface CalendarState {
   year: number;
   month: number;
 }
 
 const day = dayjs();
-
-const initialState: CalenderState = {
-  year: day.year(),
-  month: day.month() + 1,
-};
+const initialState = formatMonth(day);
 
 const calendarSlice = createSlice({
   name: 'calendar',
   initialState,
   reducers: {
-    set_month(state, action: PayloadAction<number>) {
-      state.month = action.payload;
+    setNextMonth(state) {
+      Object.assign(state, ShiftedMonth(state, 1));
+    },
+    setPrevMonth(state) {
+      Object.assign(state, ShiftedMonth(state, -1));
     },
   },
 });

--- a/front/src/utils/calendar.ts
+++ b/front/src/utils/calendar.ts
@@ -1,12 +1,12 @@
 import dayjs from 'dayjs';
 
-import { CalenderState } from '@/stores';
+import { CalendarState } from '@/stores';
 
 dayjs.locale('ja');
 
 export const createCalendar = (
   count: number,
-  calendar: CalenderState,
+  calendar: CalendarState,
 ): dayjs.Dayjs[] => {
   const firstDay = getFirstDayOfMonth(calendar);
 
@@ -20,7 +20,7 @@ export const createCalendar = (
     });
 };
 
-export const getFirstDayOfMonth = ({ year, month }: CalenderState) => {
+export const getFirstDayOfMonth = ({ year, month }: CalendarState) => {
   return dayjs(`${year}-${month}`);
 };
 
@@ -37,3 +37,13 @@ export const isToday = (day: dayjs.Dayjs) => {
 export const isFirstDay = (day: dayjs.Dayjs) => {
   return day.date() === 1;
 };
+
+export const ShiftedMonth = (calendar: CalendarState, diff: number) => {
+  const date = getFirstDayOfMonth(calendar).add(diff, 'month');
+  return formatMonth(date);
+};
+
+export const formatMonth = (date: dayjs.Dayjs): CalendarState => ({
+  month: date.month() + 1,
+  year: date.year(),
+});


### PR DESCRIPTION
# 概要
カレンダーの月を前後移動するための処理を実装した。
- [x] [✨ 月を移動するためのロジック実装](https://github.com/PenPeen/react_calendar_app/commit/20fdb935d95e5bf760dccefec84d82e4b4aec394)
- [x]  [✨ reducerの更新](https://github.com/PenPeen/react_calendar_app/commit/5a273b6b7e5057923bda6174ad68478920eea62d)
- [x]  [✨ dispatch処理の実装](https://github.com/PenPeen/react_calendar_app/commit/6edc32fe94e29841c89bc804c14a8ec1e39ea89b)


# UI
<img width="1408" alt="image" src="https://github.com/PenPeen/react_calendar_app/assets/87213337/410a5fac-66a8-44e9-a111-42e1d09970ee">

<img width="1422" alt="image" src="https://github.com/PenPeen/react_calendar_app/assets/87213337/87c5f917-b186-4823-8419-387993d37544">
