### PR TITLE
:zap: 当月を判定するロジック及びデザインの修正

### DIFF
--- a/front/src/components/CalendarElement/index.tsx
+++ b/front/src/components/CalendarElement/index.tsx
@@ -1,10 +1,13 @@
 import { FC } from 'react';
 
 import { ImageListItem, Typography } from '@mui/material';
+import { grey } from '@mui/material/colors';
 import dayjs from 'dayjs';
+import { useSelector } from 'react-redux';
 
 import { styledDate, styledElement, styledToday } from './styles';
 
+import { RootState } from '@/stores';
 import { isCurrentMonth, isFirstDay, isToday } from '@/utils/calendar';
 
 type Props = {
@@ -12,8 +15,14 @@ type Props = {
 };
 
 const CalendarElement: FC<Props> = ({ day }) => {
+  const currentMonth = useSelector<RootState, number>(
+    (state) => state.calendar.month,
+  );
+
   const format = isFirstDay(day) ? 'M月D日' : 'D';
-  const textColor = isCurrentMonth(day) ? 'textPrimary' : 'textSecondary';
+  const textColor = isCurrentMonth(day, currentMonth)
+    ? 'textPrimary'
+    : grey[400];
 
   return (
     <ImageListItem style={styledElement}>

--- a/front/src/utils/calendar.ts
+++ b/front/src/utils/calendar.ts
@@ -24,9 +24,8 @@ export const getFirstDayOfMonth = ({ year, month }: CalendarState) => {
   return dayjs(`${year}-${month}`);
 };
 
-export const isCurrentMonth = (day: dayjs.Dayjs) => {
-  const today = dayjs();
-  return day.month() === today.month();
+export const isCurrentMonth = (day: dayjs.Dayjs, currentMonth: number) => {
+  return day.month() + 1 === currentMonth;
 };
 
 export const isToday = (day: dayjs.Dayjs) => {


### PR DESCRIPTION
# 概要
- 今月を判定するロジックが月を前後しても正しく動くように
- 今月以外の日付のスタイルをより白くして目立つように

# UI
<img width="1414" alt="image" src="https://github.com/PenPeen/react_calendar_app/assets/87213337/58bac2e9-1b26-42f1-9381-a2a15413160f">


