### PR TITLE
フォーム状態をグローバル管理するためのscheduleFormSlice定義

### DIFF
--- a/front/src/stores/index.ts
+++ b/front/src/stores/index.ts
@@ -1,10 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit';
 
 import calendarSlice from './calendar';
+import { scheduleFormSlice } from './scheduleForm';
 
 const store = configureStore({
   reducer: {
     calendar: calendarSlice.reducer,
+    scheduleForn: scheduleFormSlice.reducer,
   },
 });
 

--- a/front/src/stores/scheduleForm.ts
+++ b/front/src/stores/scheduleForm.ts
@@ -1,0 +1,39 @@
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+
+interface FormInput {
+  title: string;
+  description: string;
+  date: string | null;
+  location: string;
+}
+
+interface ScheduleState {
+  form: FormInput;
+  isDialogOpen: boolean;
+}
+
+const initialState: ScheduleState = {
+  form: {
+    title: '',
+    description: '',
+    date: null,
+    location: '',
+  },
+  isDialogOpen: false,
+};
+
+export const scheduleFormSlice = createSlice({
+  name: 'scheduleForm',
+  initialState,
+  reducers: {
+    setValue(state, action: PayloadAction<FormInput>) {
+      state.form = action.payload;
+    },
+    openDialog(state) {
+      state.isDialogOpen = true;
+    },
+    closeDialog(state) {
+      state.isDialogOpen = false;
+    },
+  },
+});


### PR DESCRIPTION
# 概要
フォーム状態をグローバル管理するためのscheduleFormSliceを定義した

# 対応事項
- [x] [✨ 予定のフォーム状態をグローバル管理するためのscheduleFormSlice定義](https://github.com/PenPeen/react_calendar_app/commit/074e85d39a9dc1f6da3c5ce07b4eac8177b96637)
- [x] [🔧 storeに追加](https://github.com/PenPeen/react_calendar_app/commit/835c07faa5dd8e3eefeb3b99bf2e74bfb50f4e71)
