### PR TITLE
ダイアログを表示 / 閉じることができるようにする

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react';
 
+import AddScheduleDialog from './components/AddScheduleDialog';
 import CalendarBoard from './components/CalendarBoard';
 import Navigation from './components/Navigation';
 import Providers from './Providers';
@@ -10,6 +11,7 @@ const App: FC = () => {
       <Providers>
         <Navigation />
         <CalendarBoard />
+        <AddScheduleDialog />
       </Providers>
     </>
   );

--- a/front/src/components/AddScheduleDialog/index.tsx
+++ b/front/src/components/AddScheduleDialog/index.tsx
@@ -1,0 +1,29 @@
+import { FC } from 'react';
+
+import { Dialog, DialogContent } from '@mui/material';
+import { useSelector } from 'react-redux';
+
+import { useScheduleForm } from '@/hooks/useScheduleForm';
+import { RootState } from '@/stores';
+import { ScheduleState } from '@/stores/scheduleForm';
+
+const AddScheduleDialog: FC = () => {
+  const scheduleForm = useSelector<RootState, ScheduleState>(
+    (state) => state.scheduleForm,
+  );
+
+  const { handleCloseDialog } = useScheduleForm();
+
+  return (
+    <Dialog
+      open={scheduleForm.isDialogOpen}
+      onClose={handleCloseDialog}
+      maxWidth="xs"
+      fullWidth
+    >
+      <DialogContent>予定登録ダイアログ （tentative）</DialogContent>
+    </Dialog>
+  );
+};
+
+export default AddScheduleDialog;

--- a/front/src/components/CalendarBoard/index.tsx
+++ b/front/src/components/CalendarBoard/index.tsx
@@ -7,10 +7,13 @@ import { styledContainer, styledGrid, styledDays } from './styles';
 import CalendarElement from '../CalendarElement';
 import { days } from '../types';
 
+import { useScheduleForm } from '@/hooks/useScheduleForm';
 import { RootState, CalendarState } from '@/stores';
 import { createCalendar } from '@/utils/calendar';
 
 const CalendarBoard: FC = () => {
+  const { handleOpenDialog } = useScheduleForm();
+
   const currentCalendar = useSelector<RootState, CalendarState>(
     (state) => state.calendar,
   );
@@ -34,7 +37,10 @@ const CalendarBoard: FC = () => {
           </li>
         ))}
         {calendar.map((day) => (
-          <CalendarElement key={day.toISOString()} day={day} />
+          // eslint-disable-next-line
+          <div key={day.toISOString()} onClick={handleOpenDialog}>
+            <CalendarElement day={day} />
+          </div>
         ))}
       </ImageList>
     </div>

--- a/front/src/hooks/useScheduleForm.ts
+++ b/front/src/hooks/useScheduleForm.ts
@@ -1,0 +1,19 @@
+import { useDispatch } from 'react-redux';
+
+import { scheduleFormSlice } from '@/stores/scheduleForm';
+
+// eslint-disable-next-line
+const { setValue, openDialog, closeDialog } = scheduleFormSlice.actions;
+
+export const useScheduleForm = () => {
+  const dispatch = useDispatch();
+  const handleSetValue = () => console.log('TODO');
+  const handleOpenDialog = () => dispatch(openDialog());
+  const handleCloseDialog = () => dispatch(closeDialog());
+
+  return {
+    handleOpenDialog,
+    handleCloseDialog,
+    handleSetValue,
+  };
+};

--- a/front/src/hooks/useScheduleForm.ts
+++ b/front/src/hooks/useScheduleForm.ts
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 import { scheduleFormSlice } from '@/stores/scheduleForm';
 
 // eslint-disable-next-line
-const { setValue, openDialog, closeDialog } = scheduleFormSlice.actions;
+const { openDialog, closeDialog } = scheduleFormSlice.actions;
 
 export const useScheduleForm = () => {
   const dispatch = useDispatch();

--- a/front/src/stores/index.ts
+++ b/front/src/stores/index.ts
@@ -6,7 +6,7 @@ import { scheduleFormSlice } from './scheduleForm';
 const store = configureStore({
   reducer: {
     calendar: calendarSlice.reducer,
-    scheduleForn: scheduleFormSlice.reducer,
+    scheduleForm: scheduleFormSlice.reducer,
   },
 });
 

--- a/front/src/stores/scheduleForm.ts
+++ b/front/src/stores/scheduleForm.ts
@@ -7,7 +7,7 @@ interface FormInput {
   location: string;
 }
 
-interface ScheduleState {
+export interface ScheduleState {
   form: FormInput;
   isDialogOpen: boolean;
 }


### PR DESCRIPTION
# 概要
予定を追加するためのダイアログの表示制御が行えるようにしました。

# 対応事項
- [x] [💩 typoしていた](https://github.com/PenPeen/react_calendar_app/commit/d351302d7f4d70f05ac47a9061337dbf8c8fc29a)
- [x]  [✨ ダイアログを制御するカスタムフックの作成](https://github.com/PenPeen/react_calendar_app/commit/475e66bb7f14f29ec5fcdd584cea18c6ca11152e)
- [x]  [🎨 ダイアログを表示 / 閉じることができるようにする](https://github.com/PenPeen/react_calendar_app/commit/fa1bcf220192e8650872fe0540556a2368ed2e37)
- [x]  [🔥 lintが失敗しないように不要な記述を削除した](https://github.com/PenPeen/react_calendar_app/commit/2b9312069591da84bbb203292db8e88b98416b7d)

# UI
<img width="926" alt="image" src="https://github.com/PenPeen/react_calendar_app/assets/87213337/3a099bf0-4e6c-4643-8cf6-37a22ad16e48">
