### PR TITLE
:sparkles: フォームの入力情報をReduxと同期させるように変更

### DIFF
--- a/front/src/components/AddScheduleDialog/index.tsx
+++ b/front/src/components/AddScheduleDialog/index.tsx
@@ -22,7 +22,7 @@ const AddScheduleDialog: FC = () => {
     (state) => state.scheduleForm,
   );
 
-  const { handleCloseDialog } = useScheduleForm();
+  const { handleCloseDialog, handleSetValue } = useScheduleForm();
 
   return (
     <Dialog
@@ -32,7 +32,12 @@ const AddScheduleDialog: FC = () => {
       fullWidth
     >
       <DialogContent>
-        <StyledInput placeholder="タイトルと日時を追加" autoFocus />
+        <StyledInput
+          value={scheduleForm.form.title}
+          onChange={(e) => handleSetValue('title', e.target.value)}
+          placeholder="タイトルと日時を追加"
+          autoFocus
+        />
         <Grid
           container
           spacing={1}
@@ -44,6 +49,8 @@ const AddScheduleDialog: FC = () => {
           </Grid>
           <Grid item xs={10}>
             <TextField
+              value={scheduleForm.form.location}
+              onChange={(e) => handleSetValue('location', e.target.value)}
               style={styledTextField}
               fullWidth
               placeholder="場所を追加"
@@ -61,6 +68,8 @@ const AddScheduleDialog: FC = () => {
           </Grid>
           <Grid item xs={10}>
             <TextField
+              value={scheduleForm.form.description}
+              onChange={(e) => handleSetValue('description', e.target.value)}
               style={styledTextField}
               fullWidth
               placeholder="説明を追加"

--- a/front/src/hooks/useScheduleForm.ts
+++ b/front/src/hooks/useScheduleForm.ts
@@ -1,12 +1,15 @@
 import { useDispatch } from 'react-redux';
 
-import { scheduleFormSlice } from '@/stores/scheduleForm';
+import { FormInput, scheduleFormSlice } from '@/stores/scheduleForm';
 
-const { openDialog, closeDialog } = scheduleFormSlice.actions;
+const { openDialog, closeDialog, setValue } = scheduleFormSlice.actions;
 
 export const useScheduleForm = () => {
   const dispatch = useDispatch();
-  const handleSetValue = () => console.log('TODO');
+  const handleSetValue = (field: keyof FormInput, value: string) => {
+    dispatch(setValue({ [field]: value }));
+  };
+
   const handleOpenDialog = () => dispatch(openDialog());
   const handleCloseDialog = () => dispatch(closeDialog());
 

--- a/front/src/stores/scheduleForm.ts
+++ b/front/src/stores/scheduleForm.ts
@@ -1,6 +1,6 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-interface FormInput {
+export interface FormInput {
   title: string;
   description: string;
   date: string | null;
@@ -26,8 +26,8 @@ export const scheduleFormSlice = createSlice({
   name: 'scheduleForm',
   initialState,
   reducers: {
-    setValue(state, action: PayloadAction<FormInput>) {
-      state.form = action.payload;
+    setValue(state, action: PayloadAction<object>) {
+      state.form = { ...state.form, ...action.payload };
     },
     openDialog(state) {
       state.isDialogOpen = true;


### PR DESCRIPTION
# 概要

スケジュールフォームに入力した値がReduxで管理されるようにした。

<img width="1431" alt="image" src="https://github.com/PenPeen/react_calendar_app/assets/87213337/07bad2e9-d53c-4d62-8675-924af2a876cd">
