### PR TITLE
フォームの日付制御

### DIFF
--- a/front/src/components/AddScheduleDialog/index.tsx
+++ b/front/src/components/AddScheduleDialog/index.tsx
@@ -1,6 +1,10 @@
 import { FC } from 'react';
 
-import { LocationOnOutlined, NotesOutlined } from '@mui/icons-material';
+import {
+  AccessTime,
+  LocationOnOutlined,
+  NotesOutlined,
+} from '@mui/icons-material';
 import {
   Button,
   Dialog,
@@ -11,7 +15,7 @@ import {
 } from '@mui/material';
 import { useSelector } from 'react-redux';
 
-import { StyledInput, styledTextField } from './styles';
+import { StyledDatePicker, StyledInput, styledTextField } from './styles';
 
 import { useScheduleForm } from '@/hooks/useScheduleForm';
 import { RootState } from '@/stores';
@@ -38,6 +42,19 @@ const AddScheduleDialog: FC = () => {
           placeholder="タイトルと日時を追加"
           autoFocus
         />
+        <Grid
+          container
+          spacing={1}
+          alignItems="center"
+          justifyContent="space-between"
+        >
+          <Grid item>
+            <AccessTime />
+          </Grid>
+          <Grid item xs={10}>
+            <StyledDatePicker format="YYYY年M月D日" />
+          </Grid>
+        </Grid>
         <Grid
           container
           spacing={1}

--- a/front/src/components/AddScheduleDialog/index.tsx
+++ b/front/src/components/AddScheduleDialog/index.tsx
@@ -13,6 +13,7 @@ import {
   Grid,
   TextField,
 } from '@mui/material';
+import dayjs from 'dayjs';
 import { useSelector } from 'react-redux';
 
 import { StyledDatePicker, StyledInput, styledTextField } from './styles';
@@ -52,7 +53,15 @@ const AddScheduleDialog: FC = () => {
             <AccessTime />
           </Grid>
           <Grid item xs={10}>
-            <StyledDatePicker format="YYYY年M月D日" />
+            <StyledDatePicker
+              format="YYYY年M月D日"
+              value={dayjs(scheduleForm.form.date)}
+              onChange={(e) => {
+                if (e && e.isValid()) {
+                  handleSetValue('date', e.toISOString());
+                }
+              }}
+            />
           </Grid>
         </Grid>
         <Grid

--- a/front/src/components/AddScheduleDialog/styles.ts
+++ b/front/src/components/AddScheduleDialog/styles.ts
@@ -1,8 +1,13 @@
+import { DatePicker } from '@mui/x-date-pickers';
 import styled from 'styled-components';
 
 export const styledTextField = {
   margin: '4px 0',
 };
+
+export const StyledDatePicker = styled(DatePicker)`
+  width: 100%;
+`;
 
 export const StyledInput = styled.input`
   width: 100%;

--- a/front/src/hooks/useScheduleForm.ts
+++ b/front/src/hooks/useScheduleForm.ts
@@ -6,10 +6,10 @@ const { openDialog, closeDialog, setValue } = scheduleFormSlice.actions;
 
 export const useScheduleForm = () => {
   const dispatch = useDispatch();
+
   const handleSetValue = (field: keyof FormInput, value: string) => {
     dispatch(setValue({ [field]: value }));
   };
-
   const handleOpenDialog = () => dispatch(openDialog());
   const handleCloseDialog = () => dispatch(closeDialog());
 

--- a/front/src/stores/scheduleForm.ts
+++ b/front/src/stores/scheduleForm.ts
@@ -1,9 +1,10 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+import dayjs from 'dayjs';
 
 export interface FormInput {
   title: string;
   description: string;
-  date: string | null;
+  date: string;
   location: string;
 }
 
@@ -16,7 +17,8 @@ const initialState: ScheduleState = {
   form: {
     title: '',
     description: '',
-    date: null,
+    // TODO: 本日の日付を仮で初期値指定
+    date: dayjs().toISOString(),
     location: '',
   },
   isDialogOpen: false,


### PR DESCRIPTION
# 概要
DatePickerを使用してカレンダーの日付表示を制御できるようにした。

# UI
![image](https://github.com/PenPeen/react_calendar_app/assets/87213337/79518967-26b2-4cbf-968c-e3fedb570d4d)
