### PR TITLE
予定を管理するScheduleSliceの作成とリファクタ

### DIFF
--- a/front/src/hooks/useScheduleForm.ts
+++ b/front/src/hooks/useScheduleForm.ts
@@ -1,13 +1,13 @@
 import { useDispatch } from 'react-redux';
 
-import { FormInput, scheduleFormSlice } from '@/stores/scheduleForm';
+import { Schedule, scheduleFormSlice } from '@/stores/scheduleForm';
 
 const { openDialog, closeDialog, setValue } = scheduleFormSlice.actions;
 
 export const useScheduleForm = () => {
   const dispatch = useDispatch();
 
-  const handleSetValue = (field: keyof FormInput, value: string) => {
+  const handleSetValue = (field: keyof Schedule, value: string) => {
     dispatch(setValue({ [field]: value }));
   };
   const handleOpenDialog = (day: string) => dispatch(openDialog(day));

--- a/front/src/hooks/useScheduleForm.ts
+++ b/front/src/hooks/useScheduleForm.ts
@@ -1,6 +1,7 @@
 import { useDispatch } from 'react-redux';
 
-import { Schedule, scheduleFormSlice } from '@/stores/scheduleForm';
+import { scheduleFormSlice } from '@/stores/scheduleForm';
+import { Schedule } from '@/types/schedule';
 
 const { openDialog, closeDialog, setValue } = scheduleFormSlice.actions;
 

--- a/front/src/stores/index.ts
+++ b/front/src/stores/index.ts
@@ -2,11 +2,13 @@ import { configureStore } from '@reduxjs/toolkit';
 
 import calendarSlice from './calendar';
 import { scheduleFormSlice } from './scheduleForm';
+import { schedulesSlice } from './schedules';
 
 const store = configureStore({
   reducer: {
     calendar: calendarSlice.reducer,
     scheduleForm: scheduleFormSlice.reducer,
+    schedules: schedulesSlice.reducer,
   },
 });
 

--- a/front/src/stores/scheduleForm.ts
+++ b/front/src/stores/scheduleForm.ts
@@ -1,6 +1,6 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-export interface FormInput {
+export interface Schedule {
   title: string;
   description: string;
   date: string;
@@ -8,7 +8,7 @@ export interface FormInput {
 }
 
 export interface ScheduleState {
-  form: FormInput;
+  form: Schedule;
   isDialogOpen: boolean;
 }
 

--- a/front/src/stores/scheduleForm.ts
+++ b/front/src/stores/scheduleForm.ts
@@ -1,11 +1,6 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-export interface Schedule {
-  title: string;
-  description: string;
-  date: string;
-  location: string;
-}
+import { Schedule } from '@/types/schedule';
 
 export interface ScheduleState {
   form: Schedule;

--- a/front/src/stores/schedules.ts
+++ b/front/src/stores/schedules.ts
@@ -1,0 +1,28 @@
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+
+import { Schedule, ScheduleItem } from '@/types/schedule';
+
+interface SchedulesState {
+  items: ScheduleItem[];
+  isLoading: boolean;
+}
+
+const initialState: SchedulesState = {
+  // TODO: DBからデータを取得して初期値を表示させる
+  items: [],
+  isLoading: false,
+};
+
+export const schedulesSlice = createSlice({
+  name: 'schedules',
+  initialState,
+  reducers: {
+    addSchedule(state, action: PayloadAction<Schedule>) {
+      // TODO: idは一意なものを指定する
+      state.items.push({ id: state.items.length + 1, ...action.payload });
+    },
+    removeSchedule(state, action: PayloadAction<number>) {
+      state.items = state.items.filter((item) => item.id !== action.payload);
+    },
+  },
+});

--- a/front/src/types/schedule.ts
+++ b/front/src/types/schedule.ts
@@ -4,3 +4,6 @@ export interface Schedule {
   date: string;
   location: string;
 }
+export interface ScheduleItem extends Schedule {
+  id: number;
+}

--- a/front/src/types/schedule.ts
+++ b/front/src/types/schedule.ts
@@ -1,0 +1,6 @@
+export interface Schedule {
+  title: string;
+  description: string;
+  date: string;
+  location: string;
+}


### PR DESCRIPTION
# 概要
- [x] [♻️ インターフェース名をより汎用的な名称に変更](https://github.com/PenPeen/react_calendar_app/commit/a7fa35d9b4bd307e11985760cd0fe590fad364e4)
- [x] [♻️ Scheduleの型定義をtypesディレクトリに移動した](https://github.com/PenPeen/react_calendar_app/commit/ed27757691480d321de7fdf14bd7d61500797576)
- [x] [✨ schedules_sliceの作成](https://github.com/PenPeen/react_calendar_app/commit/01aabf03e3b8c7c7e62be925e3c92e6240842a60)
- [x] [⚡ storeにreducerを登録](https://github.com/PenPeen/react_calendar_app/commit/0263e115b0e71b10e28129c7caa0b7b93023c5c6)