### PR TITLE
:sparkles: 予定の詳細データを管理するSliceの定義

### DIFF
--- a/front/src/stores/currentSchedule.ts
+++ b/front/src/stores/currentSchedule.ts
@@ -1,0 +1,34 @@
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+
+import { Schedule } from '@/types/schedule';
+
+type ScheduleState = {
+  current: Schedule;
+  isDialogOpen: boolean;
+};
+
+const initialState: ScheduleState = {
+  current: {
+    title: '',
+    description: '',
+    date: '',
+    location: '',
+  },
+  isDialogOpen: false,
+};
+
+export const currentScheduleSlice = createSlice({
+  name: 'currentSchedule',
+  initialState,
+  reducers: {
+    setItem(state, action: PayloadAction<object>) {
+      state.current = { ...state.current, ...action.payload };
+    },
+    openDialog(state) {
+      state.isDialogOpen = true;
+    },
+    closeDialog(state) {
+      state.isDialogOpen = false;
+    },
+  },
+});

--- a/front/src/stores/index.ts
+++ b/front/src/stores/index.ts
@@ -1,6 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit';
 
 import calendarSlice from './calendar';
+import { currentScheduleSlice } from './currentSchedule';
 import { scheduleFormSlice } from './scheduleForm';
 import { schedulesSlice } from './schedules';
 
@@ -9,6 +10,7 @@ const store = configureStore({
     calendar: calendarSlice.reducer,
     scheduleForm: scheduleFormSlice.reducer,
     schedules: schedulesSlice.reducer,
+    currentSchedule: currentScheduleSlice.reducer,
   },
 });
 


### PR DESCRIPTION
# 概要

予定の詳細データを管理するSliceを定義した

# イメージ
![image](https://github.com/PenPeen/react_calendar_app/assets/87213337/87375160-5fbb-43f3-bb73-0f1451dc0f7c)
