### PR TITLE
予定クリック時にダイアログコンポーネントを表示する

### DIFF
--- a/front/src/components/Schedule/index.tsx
+++ b/front/src/components/Schedule/index.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 
 import { StyleProps, StyledSchedule } from './styles';
 
+import { useCurrentSchedule } from '@/hooks/useCurrentSchedule';
 import { ScheduleItem } from '@/types';
 
 type Props = {
@@ -10,7 +11,20 @@ type Props = {
 };
 
 const Schedule: FC<Props> = ({ schedule, custom }) => {
-  return <StyledSchedule {...custom}>{schedule.title}</StyledSchedule>;
+  const handleScheduleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+
+    handleSetCurrent(schedule);
+    handleOpenDialog();
+  };
+
+  const { handleSetCurrent, handleOpenDialog } = useCurrentSchedule();
+
+  return (
+    <StyledSchedule {...custom} onClick={(e) => handleScheduleClick(e)}>
+      {schedule.title}
+    </StyledSchedule>
+  );
 };
 
 export default Schedule;

--- a/front/src/hooks/useCurrentSchedule.ts
+++ b/front/src/hooks/useCurrentSchedule.ts
@@ -1,14 +1,14 @@
 import { useDispatch } from 'react-redux';
 
 import { currentScheduleSlice } from '@/stores/currentSchedule';
-import { Schedule } from '@/types/schedule';
+import { ScheduleItem } from '@/types/schedule';
 
 const { openDialog, closeDialog, setCurrent } = currentScheduleSlice.actions;
 
 export const useCurrentSchedule = () => {
   const dispatch = useDispatch();
 
-  const handleSetCurrent = (current: Schedule) => {
+  const handleSetCurrent = (current: ScheduleItem) => {
     dispatch(setCurrent(current));
   };
   const handleOpenDialog = () => dispatch(openDialog());

--- a/front/src/stores/currentSchedule.ts
+++ b/front/src/stores/currentSchedule.ts
@@ -1,14 +1,15 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-import { Schedule } from '@/types/schedule';
+import { ScheduleItem } from '@/types/schedule';
 
 export interface CurrentScheduleState {
-  current: Schedule;
+  current: ScheduleItem;
   isDialogOpen: boolean;
 }
 
 const initialState: CurrentScheduleState = {
   current: {
+    id: null as never,
     title: '',
     description: '',
     date: '',
@@ -21,7 +22,7 @@ export const currentScheduleSlice = createSlice({
   name: 'currentSchedule',
   initialState,
   reducers: {
-    setCurrent(state, action: PayloadAction<Schedule>) {
+    setCurrent(state, action: PayloadAction<ScheduleItem>) {
       state.current = action.payload;
     },
     openDialog(state) {


### PR DESCRIPTION
# 概要

予定を表示するためのコンポーネント定義

# UI
※ デザイン/ フォーマットは後ほど修正
<img width="1429" alt="image" src="https://github.com/PenPeen/react_calendar_app/assets/87213337/33e764af-7f10-4a3b-ad58-59b347fea4a8">
