### PR TITLE
:recycle: コンポーネントからHook処理を分割

### DIFF
--- a/front/src/components/AddScheduleDialog/index.tsx
+++ b/front/src/components/AddScheduleDialog/index.tsx
@@ -16,21 +16,17 @@ import {
   TextField,
 } from '@mui/material';
 import dayjs from 'dayjs';
-import { useSelector } from 'react-redux';
 
 import { StyledDatePicker, StyledInput, styledTextField } from './styles';
 
-import { useScheduleForm } from '@/hooks/useScheduleForm';
-import { RootState } from '@/stores';
-import { ScheduleState } from '@/stores/scheduleForm';
+import { useScheduleFormAction } from '@/hooks/useScheduleFormAction';
+import { useScheduleFormState } from '@/hooks/useScheduleFormState';
 
 const AddScheduleDialog: FC = () => {
-  const scheduleForm = useSelector<RootState, ScheduleState>(
-    (state) => state.scheduleForm,
-  );
+  const scheduleForm = useScheduleFormState();
 
   const { handleCloseDialog, handleSetValue, handleStoreForm } =
-    useScheduleForm();
+    useScheduleFormAction();
 
   return (
     <Dialog

--- a/front/src/components/CalendarBoard/index.tsx
+++ b/front/src/components/CalendarBoard/index.tsx
@@ -1,26 +1,22 @@
 import { FC } from 'react';
 
 import { ImageList, Typography } from '@mui/material';
-import { useSelector } from 'react-redux';
 
 import { styledContainer, styledGrid, styledDays } from './styles';
 import CalendarElement from '../CalendarElement';
 
-import { useScheduleForm } from '@/hooks/useScheduleForm';
-import { RootState, CalendarState } from '@/stores';
+import { useCurrentCalendarState } from '@/hooks/useCurrentCalendarState';
+import { useFetchScheduleAction } from '@/hooks/useFetchScheduleAction';
+import { useScheduleFormAction } from '@/hooks/useScheduleFormAction';
+import { useSchedulesState } from '@/hooks/useSchedulesState';
 import { days } from '@/types';
-import { ScheduleItem } from '@/types/schedule';
 import { createCalendar, mapSchedulesToDate } from '@/utils/calendar';
 
 const CalendarBoard: FC = () => {
-  const { handleOpenDialog } = useScheduleForm();
-
-  const currentCalendar = useSelector<RootState, CalendarState>(
-    (state) => state.calendar,
-  );
-  const schedules = useSelector<RootState, ScheduleItem[]>(
-    (state) => state.schedules.items,
-  );
+  const { handleOpenDialog } = useScheduleFormAction();
+  const schedules = useSchedulesState();
+  const currentCalendar = useCurrentCalendarState();
+  useFetchScheduleAction(currentCalendar);
 
   const calendar = mapSchedulesToDate(
     createCalendar(35, currentCalendar),

--- a/front/src/components/CalendarElement/index.tsx
+++ b/front/src/components/CalendarElement/index.tsx
@@ -3,7 +3,6 @@ import { FC } from 'react';
 import { ImageListItem, Typography } from '@mui/material';
 import { grey } from '@mui/material/colors';
 import dayjs from 'dayjs';
-import { useSelector } from 'react-redux';
 
 import {
   StyledScheduleContainer,
@@ -13,8 +12,8 @@ import {
 } from './styles';
 import Schedule from '../Schedule';
 
-import { RootState } from '@/stores';
-import { ScheduleItem } from '@/types/schedule';
+import { useCurrentCalendarState } from '@/hooks/useCurrentCalendarState';
+import { ScheduleItem } from '@/types';
 import { isCurrentMonth, isFirstDay, isToday } from '@/utils/calendar';
 
 type Props = {
@@ -23,9 +22,7 @@ type Props = {
 };
 
 const CalendarElement: FC<Props> = ({ day, schedules }) => {
-  const currentMonth = useSelector<RootState, number>(
-    (state) => state.calendar.month,
-  );
+  const { month: currentMonth } = useCurrentCalendarState();
 
   const format = isFirstDay(day) ? 'M月D日' : 'D';
   const textColor = isCurrentMonth(day, currentMonth)

--- a/front/src/components/CurrentScheduleDialog/index.tsx
+++ b/front/src/components/CurrentScheduleDialog/index.tsx
@@ -10,7 +10,6 @@ import {
   Typography,
 } from '@mui/material';
 import dayjs from 'dayjs';
-import { useSelector } from 'react-redux';
 
 import {
   mainBlock,
@@ -20,16 +19,12 @@ import {
   tbtlBlock,
 } from './styles';
 
-import { useCurrentSchedule } from '@/hooks/useCurrentSchedule';
-import { RootState } from '@/stores';
-import { CurrentScheduleState } from '@/stores/currentSchedule';
+import { useCurrentScheduleAction } from '@/hooks/useCurrentScheduleAction';
+import { useCurrentScheduleState } from '@/hooks/useCurrentScheduleState';
 
 const CurrentScheduleDialog: FC = () => {
-  const { handleCloseDialog } = useCurrentSchedule();
-
-  const currentSchedule = useSelector<RootState, CurrentScheduleState>(
-    (state) => state.currentSchedule,
-  );
+  const { handleCloseDialog } = useCurrentScheduleAction();
+  const currentSchedule = useCurrentScheduleState();
 
   return (
     <>

--- a/front/src/components/Navigation/index.tsx
+++ b/front/src/components/Navigation/index.tsx
@@ -4,7 +4,6 @@ import { ArrowBackIos, ArrowForwardIos } from '@mui/icons-material';
 import MenuIcon from '@mui/icons-material/Menu';
 import { IconButton, Toolbar, Typography } from '@mui/material';
 import dayjs from 'dayjs';
-import { useSelector } from 'react-redux';
 
 import {
   StyledDatePicker,
@@ -14,13 +13,11 @@ import {
 } from './style';
 
 import { useCalendar } from '@/hooks/useCalendarAction';
-import { CalendarState, RootState } from '@/stores';
+import { useCurrentCalendarState } from '@/hooks/useCurrentCalendarState';
 
 const Navigation: FC = () => {
   const { handlePrevMonth, handleNextMonth, handleSetMonth } = useCalendar();
-  const calendar = useSelector<RootState, CalendarState>(
-    (state) => state.calendar,
-  );
+  const calendar = useCurrentCalendarState();
   const calendarDate = dayjs(new Date(calendar.year, calendar.month - 1));
 
   return (

--- a/front/src/components/Schedule/index.tsx
+++ b/front/src/components/Schedule/index.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react';
 
 import { StyleProps, StyledSchedule } from './styles';
 
-import { useCurrentSchedule } from '@/hooks/useCurrentSchedule';
+import { useCurrentScheduleAction } from '@/hooks/useCurrentScheduleAction';
 import { ScheduleItem } from '@/types';
 
 type Props = {
@@ -18,7 +18,7 @@ const Schedule: FC<Props> = ({ schedule, custom }) => {
     handleOpenDialog();
   };
 
-  const { handleSetCurrent, handleOpenDialog } = useCurrentSchedule();
+  const { handleSetCurrent, handleOpenDialog } = useCurrentScheduleAction();
 
   return (
     <StyledSchedule {...custom} onClick={(e) => handleScheduleClick(e)}>

--- a/front/src/hooks/useCurrentCalendarState.ts
+++ b/front/src/hooks/useCurrentCalendarState.ts
@@ -1,0 +1,11 @@
+import { useSelector } from 'react-redux';
+
+import { CalendarState, RootState } from '@/stores';
+
+export const useCurrentCalendarState = () => {
+  const currentCalendar = useSelector<RootState, CalendarState>(
+    (state) => state.calendar,
+  );
+
+  return currentCalendar;
+};

--- a/front/src/hooks/useCurrentScheduleAction.ts
+++ b/front/src/hooks/useCurrentScheduleAction.ts
@@ -5,7 +5,7 @@ import { ScheduleItem } from '@/types/schedule';
 
 const { openDialog, closeDialog, setCurrent } = currentScheduleSlice.actions;
 
-export const useCurrentSchedule = () => {
+export const useCurrentScheduleAction = () => {
   const dispatch = useDispatch();
 
   const handleSetCurrent = (current: ScheduleItem) => {

--- a/front/src/hooks/useCurrentScheduleState.ts
+++ b/front/src/hooks/useCurrentScheduleState.ts
@@ -1,0 +1,12 @@
+import { useSelector } from 'react-redux';
+
+import { RootState } from '@/stores';
+import { CurrentScheduleState } from '@/stores/currentSchedule';
+
+export const useCurrentScheduleState = () => {
+  const currentSchedule = useSelector<RootState, CurrentScheduleState>(
+    (state) => state.currentSchedule,
+  );
+
+  return currentSchedule;
+};

--- a/front/src/hooks/useFetchScheduleAction.ts
+++ b/front/src/hooks/useFetchScheduleAction.ts
@@ -7,7 +7,7 @@ import { schedulesSlice } from '@/stores/schedules';
 import { get } from '@/utils/api';
 const { setLoading, fetchSchedule } = schedulesSlice.actions;
 
-export const useFetchSchedule = (currentCalendar: CalendarState) => {
+export const useFetchScheduleAction = (currentCalendar: CalendarState) => {
   const dispatch = useDispatch();
 
   useEffect(() => {

--- a/front/src/hooks/useScheduleFormAction.ts
+++ b/front/src/hooks/useScheduleFormAction.ts
@@ -7,7 +7,7 @@ import { Schedule } from '@/types/schedule';
 const { openDialog, closeDialog, setValue } = scheduleFormSlice.actions;
 const { addSchedule } = schedulesSlice.actions;
 
-export const useScheduleForm = () => {
+export const useScheduleFormAction = () => {
   const dispatch = useDispatch();
 
   const handleSetValue = (field: keyof Schedule, value: string) => {

--- a/front/src/hooks/useScheduleFormState.ts
+++ b/front/src/hooks/useScheduleFormState.ts
@@ -1,0 +1,12 @@
+import { useSelector } from 'react-redux';
+
+import { RootState } from '@/stores';
+import { ScheduleState } from '@/stores/scheduleForm';
+
+export const useScheduleFormState = () => {
+  const scheduleForm = useSelector<RootState, ScheduleState>(
+    (state) => state.scheduleForm,
+  );
+
+  return scheduleForm;
+};

--- a/front/src/hooks/useSchedulesState.ts
+++ b/front/src/hooks/useSchedulesState.ts
@@ -1,0 +1,12 @@
+import { useSelector } from 'react-redux';
+
+import { RootState } from '@/stores';
+import { ScheduleItem } from '@/types';
+
+export const useSchedulesState = () => {
+  const schedules = useSelector<RootState, ScheduleItem[]>(
+    (state) => state.schedules.items,
+  );
+
+  return schedules;
+};


### PR DESCRIPTION
# 概要

以下の理由から、コンポーネントからHook処理を分離しました。

- コンポーネントのHookロジックが肥大化していた
- 共通化できるロジックがあった