### PR TITLE
:sparkles: 予定の削除機能の実装

### DIFF
--- a/front/src/components/CurrentScheduleDialog/index.tsx
+++ b/front/src/components/CurrentScheduleDialog/index.tsx
@@ -1,6 +1,11 @@
 import { FC } from 'react';
 
-import { Close, LocationOnOutlined, NotesOutlined } from '@mui/icons-material';
+import {
+  Close,
+  DeleteOutlineOutlined,
+  LocationOnOutlined,
+  NotesOutlined,
+} from '@mui/icons-material';
 import {
   Dialog,
   DialogActions,
@@ -23,7 +28,7 @@ import { useCurrentScheduleAction } from '@/hooks/useCurrentScheduleAction';
 import { useCurrentScheduleState } from '@/hooks/useCurrentScheduleState';
 
 const CurrentScheduleDialog: FC = () => {
-  const { handleCloseDialog } = useCurrentScheduleAction();
+  const { handleCloseDialog, handleDeleteForm } = useCurrentScheduleAction();
   const currentSchedule = useCurrentScheduleState();
 
   return (
@@ -36,6 +41,12 @@ const CurrentScheduleDialog: FC = () => {
       >
         <DialogActions>
           <div style={styledCloseButton}>
+            <IconButton
+              onClick={() => handleDeleteForm(currentSchedule.current.id)}
+              size="small"
+            >
+              <DeleteOutlineOutlined />
+            </IconButton>
             <IconButton onClick={handleCloseDialog} size="small">
               <Close />
             </IconButton>

--- a/front/src/hooks/useCurrentScheduleAction.ts
+++ b/front/src/hooks/useCurrentScheduleAction.ts
@@ -1,9 +1,12 @@
 import { useDispatch } from 'react-redux';
 
 import { currentScheduleSlice } from '@/stores/currentSchedule';
+import { schedulesSlice } from '@/stores/schedules';
 import { ScheduleItem } from '@/types/schedule';
+import { deleteReq } from '@/utils/api';
 
 const { openDialog, closeDialog, setCurrent } = currentScheduleSlice.actions;
+const { setLoading, removeSchedule } = schedulesSlice.actions;
 
 export const useCurrentScheduleAction = () => {
   const dispatch = useDispatch();
@@ -13,10 +16,17 @@ export const useCurrentScheduleAction = () => {
   };
   const handleOpenDialog = () => dispatch(openDialog());
   const handleCloseDialog = () => dispatch(closeDialog());
+  const handleDeleteForm = async (id: number) => {
+    dispatch(setLoading());
+    await deleteReq(`schedules/${id}`);
+    dispatch(removeSchedule(id));
+    dispatch(closeDialog());
+  };
 
   return {
     handleOpenDialog,
     handleCloseDialog,
     handleSetCurrent,
+    handleDeleteForm,
   };
 };

--- a/front/src/stores/schedules.ts
+++ b/front/src/stores/schedules.ts
@@ -21,6 +21,7 @@ export const schedulesSlice = createSlice({
     },
     removeSchedule(state, action: PayloadAction<number>) {
       state.items = state.items.filter((item) => item.id !== action.payload);
+      state.isLoading = false;
     },
     fetchSchedule(state, action: PayloadAction<ScheduleItem[]>) {
       state.items = action.payload;

--- a/front/src/utils/api.ts
+++ b/front/src/utils/api.ts
@@ -26,3 +26,10 @@ export const post = async (
 
   return result;
 };
+
+export const deleteReq = async (path: string) => {
+  const options = { method: 'DELETE' };
+  await fetch(url(path), options);
+
+  return;
+};


### PR DESCRIPTION
# 概要
予定の詳細表示モーダルから、予定の削除ができるようにした。

# UI
<img width="1432" alt="image" src="https://github.com/PenPeen/react_calendar_app/assets/87213337/c21db28f-e3d6-4d01-ad8d-8b0f5e44695d">
