### PR TITLE
:zap: スタイルオブジェクトに対して、React.CSSPropertiesを指定

### DIFF
--- a/front/src/components/AddScheduleDialog/styles.ts
+++ b/front/src/components/AddScheduleDialog/styles.ts
@@ -1,7 +1,7 @@
 import { DatePicker } from '@mui/x-date-pickers';
 import styled from 'styled-components';
 
-export const styledTextField = {
+export const styledTextField: React.CSSProperties = {
   margin: '4px 0',
 };
 

--- a/front/src/components/CalendarBoard/styles.ts
+++ b/front/src/components/CalendarBoard/styles.ts
@@ -1,13 +1,13 @@
-export const styledContainer = {
+export const styledContainer: React.CSSProperties = {
   height: '90vh',
 };
 
-export const styledGrid = {
+export const styledGrid: React.CSSProperties = {
   borderLeft: '1px solid #ccc',
   borderTop: '1px solid #ccc',
 };
 
-export const styledDays = {
+export const styledDays: React.CSSProperties = {
   borderRight: '1px solid #ccc',
   paddingTop: '10px',
 };

--- a/front/src/components/CalendarElement/styles.ts
+++ b/front/src/components/CalendarElement/styles.ts
@@ -1,17 +1,17 @@
 import styled from 'styled-components';
 
-export const styledElement = {
+export const styledElement: React.CSSProperties = {
   borderRight: '1px solid #ccc',
   borderBottom: '1px solid #ccc',
   height: '18vh',
 };
 
-export const styledDate = {
+export const styledDate: React.CSSProperties = {
   padding: '5px 0',
   height: '24px',
 };
 
-export const styledToday = {
+export const styledToday: React.CSSProperties = {
   display: 'inline-block',
   lineHeight: '24px',
   width: '24px',

--- a/front/src/components/CurrentScheduleDialog/styles.ts
+++ b/front/src/components/CurrentScheduleDialog/styles.ts
@@ -6,7 +6,7 @@ export const styledCloseButton: React.CSSProperties = {
   textAlign: 'right',
 };
 
-export const styledBox = {
+export const styledBox: React.CSSProperties = {
   backgroundColor: 'rgb(121, 134, 203)',
   width: '16px',
   height: '16px',

--- a/front/src/components/Navigation/style.ts
+++ b/front/src/components/Navigation/style.ts
@@ -1,12 +1,16 @@
 import { DatePicker } from '@mui/x-date-pickers';
 import styled from 'styled-components';
 
-export const styledToolbar = {
+export const styledToolbar: React.CSSProperties = {
   padding: '0',
 };
 
-export const styledTypography = {
+export const styledTypography: React.CSSProperties = {
   margin: '0 30px 0 10px',
+};
+
+export const styledAppImage: React.CSSProperties = {
+  marginLeft: 'auto',
 };
 
 export const StyledDatePicker = styled(DatePicker)`
@@ -20,7 +24,3 @@ export const StyledDatePicker = styled(DatePicker)`
     border-radius: 0;
   }
 `;
-
-export const styledAppImage = {
-  marginLeft: 'auto',
-};


### PR DESCRIPTION
# 概要
- [x] [⚡ スタイルオブジェクトに対して、React.CSSPropertiesを指定](https://github.com/PenPeen/react_calendar_app/commit/d71d231735771d51ca9f08ac1235ef7604e55a2a)

型推論が自動でされていなかったため、適用した