### PR TITLE
タイトルが未入力の場合は、バリデーションが発火するようにする

### DIFF
--- a/front/src/components/AddScheduleDialog/index.tsx
+++ b/front/src/components/AddScheduleDialog/index.tsx
@@ -51,10 +51,13 @@ const AddScheduleDialog: FC = () => {
         <Box sx={{ mb: '32px' }}>
           <StyledInput
             value={scheduleForm.form.title}
-            onChange={(e) => handleSetValue('title', e.target.value)}
+            onChange={(e) => {
+              handleEditing();
+              handleSetValue('title', e.target.value);
+            }}
             placeholder="タイトルを追加"
             autoFocus
-            onBlur={handleEditing}
+            // onBlur={handleEditing}
           />
           <div>
             {isTitleInvalid(scheduleForm) && (

--- a/front/src/components/AddScheduleDialog/index.tsx
+++ b/front/src/components/AddScheduleDialog/index.tsx
@@ -7,6 +7,7 @@ import {
   NotesOutlined,
 } from '@mui/icons-material';
 import {
+  Box,
   Button,
   Dialog,
   DialogActions,
@@ -17,7 +18,13 @@ import {
 } from '@mui/material';
 import dayjs from 'dayjs';
 
-import { StyledDatePicker, StyledInput, styledTextField } from './styles';
+import {
+  StyledDatePicker,
+  StyledInput,
+  StyledValidationMessage,
+  styledTextField,
+} from './styles';
+import { isTitleInvalid } from './validate';
 
 import { useScheduleFormAction } from '@/hooks/useScheduleFormAction';
 import { useScheduleFormState } from '@/hooks/useScheduleFormState';
@@ -25,7 +32,7 @@ import { useScheduleFormState } from '@/hooks/useScheduleFormState';
 const AddScheduleDialog: FC = () => {
   const scheduleForm = useScheduleFormState();
 
-  const { handleCloseDialog, handleSetValue, handleStoreForm } =
+  const { handleCloseDialog, handleSetValue, handleStoreForm, handleEditing } =
     useScheduleFormAction();
 
   return (
@@ -41,12 +48,22 @@ const AddScheduleDialog: FC = () => {
         </IconButton>
       </DialogActions>
       <DialogContent>
-        <StyledInput
-          value={scheduleForm.form.title}
-          onChange={(e) => handleSetValue('title', e.target.value)}
-          placeholder="タイトルを追加"
-          autoFocus
-        />
+        <Box sx={{ mb: '32px' }}>
+          <StyledInput
+            value={scheduleForm.form.title}
+            onChange={(e) => handleSetValue('title', e.target.value)}
+            placeholder="タイトルを追加"
+            autoFocus
+            onBlur={handleEditing}
+          />
+          <div>
+            {isTitleInvalid(scheduleForm) && (
+              <StyledValidationMessage>
+                タイトルは必須です。
+              </StyledValidationMessage>
+            )}
+          </div>
+        </Box>
         <Grid
           container
           spacing={1}
@@ -112,6 +129,7 @@ const AddScheduleDialog: FC = () => {
           color="primary"
           variant="outlined"
           onClick={() => handleStoreForm(scheduleForm.form)}
+          disabled={isTitleInvalid(scheduleForm)}
         >
           保存
         </Button>

--- a/front/src/components/AddScheduleDialog/styles.ts
+++ b/front/src/components/AddScheduleDialog/styles.ts
@@ -9,9 +9,20 @@ export const StyledDatePicker = styled(DatePicker)`
   width: 100%;
 `;
 
+export const StyledValidationMessage = styled.div`
+  border-top: solid 1px;
+  height: 32px;
+  margin: 0;
+  font-family: 'Roboto', 'Helvetica', 'Arial', sans-serif;
+  font-weight: 400;
+  font-size: 0.75rem;
+  line-height: 1.66;
+  letter-spacing: 0.03333em;
+  color: #d32f2f;
+`;
+
 export const StyledInput = styled.input`
   width: 100%;
-  margin-bottom: 32px;
   font-size: 22px;
   border: none;
 

--- a/front/src/components/AddScheduleDialog/validate.ts
+++ b/front/src/components/AddScheduleDialog/validate.ts
@@ -1,0 +1,5 @@
+import { ScheduleState } from '@/stores/scheduleForm';
+
+export const isTitleInvalid = (scheduleForm: ScheduleState): boolean => {
+  return !scheduleForm.form.title && scheduleForm.isEditing;
+};

--- a/front/src/hooks/useScheduleFormAction.ts
+++ b/front/src/hooks/useScheduleFormAction.ts
@@ -5,7 +5,8 @@ import { schedulesSlice } from '@/stores/schedules';
 import { Schedule, ScheduleItem } from '@/types/schedule';
 import { storeScheduleRequest } from '@/utils/api';
 const { setLoading, addSchedule } = schedulesSlice.actions;
-const { openDialog, closeDialog, setValue } = scheduleFormSlice.actions;
+const { openDialog, closeDialog, setValue, editing, endEditing } =
+  scheduleFormSlice.actions;
 
 export const useScheduleFormAction = () => {
   const dispatch = useDispatch();
@@ -14,7 +15,10 @@ export const useScheduleFormAction = () => {
     dispatch(setValue({ [field]: value }));
   };
   const handleOpenDialog = (day: string) => dispatch(openDialog(day));
-  const handleCloseDialog = () => dispatch(closeDialog());
+  const handleCloseDialog = () => {
+    dispatch(closeDialog());
+    dispatch(endEditing());
+  };
   const handleStoreForm = async (schedule: Schedule) => {
     dispatch(setLoading());
 
@@ -24,11 +28,13 @@ export const useScheduleFormAction = () => {
     dispatch(addSchedule(result));
     dispatch(closeDialog());
   };
+  const handleEditing = () => dispatch(editing());
 
   return {
     handleOpenDialog,
     handleCloseDialog,
     handleSetValue,
     handleStoreForm,
+    handleEditing,
   };
 };

--- a/front/src/hooks/useScheduleFormAction.ts
+++ b/front/src/hooks/useScheduleFormAction.ts
@@ -20,6 +20,11 @@ export const useScheduleFormAction = () => {
     dispatch(endEditing());
   };
   const handleStoreForm = async (schedule: Schedule) => {
+    if (schedule.title === '') {
+      dispatch(editing());
+      return;
+    }
+
     dispatch(setLoading());
 
     const body: Schedule = { ...schedule, date: schedule.date };

--- a/front/src/stores/scheduleForm.ts
+++ b/front/src/stores/scheduleForm.ts
@@ -5,6 +5,7 @@ import { Schedule } from '@/types/schedule';
 export interface ScheduleState {
   form: Schedule;
   isDialogOpen: boolean;
+  isEditing: boolean;
 }
 
 const initialState: ScheduleState = {
@@ -15,6 +16,7 @@ const initialState: ScheduleState = {
     location: '',
   },
   isDialogOpen: false,
+  isEditing: false,
 };
 
 export const scheduleFormSlice = createSlice({
@@ -30,6 +32,12 @@ export const scheduleFormSlice = createSlice({
     },
     closeDialog(state) {
       state.isDialogOpen = false;
+    },
+    editing(state) {
+      state.isEditing = true;
+    },
+    endEditing(state) {
+      state.isEditing = false;
     },
   },
 });


### PR DESCRIPTION
# 概要
タイトルが入力されていない場合は、保存ができないようフロント側でバリデーションを実施するようにした。

# UI
![image](https://github.com/PenPeen/react_calendar_app/assets/87213337/1400e898-25b3-4d47-a283-6ab2ad4dcef2)
