### PR TITLE
:sparkles: 絵文字が入力された場合はエラーメッセージを表示する

### DIFF
--- a/front/src/components/AddScheduleDialog/index.tsx
+++ b/front/src/components/AddScheduleDialog/index.tsx
@@ -25,7 +25,7 @@ import {
   StyledValidationMessage,
   styledTextField,
 } from './styles';
-import { isTitleInvalid } from './validate';
+import { isContainsEmoji, isFormInvalid, isTitleInvalid } from './validate';
 
 import { useScheduleFormAction } from '@/hooks/useScheduleFormAction';
 import { useScheduleFormState } from '@/hooks/useScheduleFormState';
@@ -73,6 +73,13 @@ const AddScheduleDialog: FC = () => {
               </StyledValidationMessage>
             )}
           </div>
+          <div>
+            {isContainsEmoji(scheduleForm.form.title) && (
+              <StyledValidationMessage>
+                絵文字は使用できません。
+              </StyledValidationMessage>
+            )}
+          </div>
         </Box>
         <Grid
           container
@@ -93,6 +100,13 @@ const AddScheduleDialog: FC = () => {
                 }
               }}
             />
+            <div>
+              {isContainsEmoji(scheduleForm.form.date) && (
+                <StyledValidationMessage>
+                  絵文字は使用できません。
+                </StyledValidationMessage>
+              )}
+            </div>
           </Grid>
         </Grid>
         <Grid
@@ -112,6 +126,13 @@ const AddScheduleDialog: FC = () => {
               fullWidth
               placeholder="場所を追加"
             />
+            <div>
+              {isContainsEmoji(scheduleForm.form.location) && (
+                <StyledValidationMessage>
+                  絵文字は使用できません。
+                </StyledValidationMessage>
+              )}
+            </div>
           </Grid>
         </Grid>
         <Grid
@@ -131,6 +152,13 @@ const AddScheduleDialog: FC = () => {
               fullWidth
               placeholder="説明を追加"
             />
+            <div>
+              {isContainsEmoji(scheduleForm.form.description) && (
+                <StyledValidationMessage>
+                  絵文字は使用できません。
+                </StyledValidationMessage>
+              )}
+            </div>
           </Grid>
         </Grid>
       </DialogContent>
@@ -139,7 +167,7 @@ const AddScheduleDialog: FC = () => {
           color="primary"
           variant="outlined"
           onClick={() => dispatchStoreForm(scheduleForm.form)}
-          disabled={isTitleInvalid(scheduleForm)}
+          disabled={isFormInvalid(scheduleForm)}
         >
           保存
         </Button>

--- a/front/src/components/AddScheduleDialog/validate.ts
+++ b/front/src/components/AddScheduleDialog/validate.ts
@@ -1,5 +1,23 @@
 import { ScheduleState } from '@/stores/scheduleForm';
+import { emoji } from '@/types/emoji';
+
+export const isFormInvalid = (scheduleForm: ScheduleState): boolean => {
+  return isTitleInvalid(scheduleForm) || isFormContainsEmoji(scheduleForm);
+};
 
 export const isTitleInvalid = (scheduleForm: ScheduleState): boolean => {
   return !scheduleForm.form.title && scheduleForm.isEditing;
+};
+
+export const isFormContainsEmoji = (scheduleForm: ScheduleState): boolean => {
+  return (
+    isContainsEmoji(scheduleForm.form.title) ||
+    isContainsEmoji(scheduleForm.form.date) ||
+    isContainsEmoji(scheduleForm.form.location) ||
+    isContainsEmoji(scheduleForm.form.description)
+  );
+};
+
+export const isContainsEmoji = (str: string): boolean => {
+  return Boolean(str.match(emoji));
 };

--- a/front/src/types/emoji.ts
+++ b/front/src/types/emoji.ts
@@ -1,0 +1,4 @@
+export const emoji = new RegExp(
+  /[\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF]/,
+  'g',
+);


### PR DESCRIPTION
# 概要

絵文字が入力された状態で保存ボタンを押すと、500エラーが発生していた。
Issue: https://github.com/PenPeen/react_calendar_app/issues/44

# 対応
絵文字が入力された場合にエラ〜メッセージが表示されるように修正を行なった。

![image](https://github.com/PenPeen/react_calendar_app/assets/87213337/81883c6b-0253-4c92-bdce-904cc38c8102)

