### PR TITLE
:bug: 数値のみ入力された場合も、テキストが正しく折り返されるように修正

### DIFF
--- a/front/src/components/Schedule/styles.ts
+++ b/front/src/components/Schedule/styles.ts
@@ -10,7 +10,6 @@ export type StyleProps = {
   $borderRadius?: string;
 };
 
-// FIXME: 数値のみ入力された場合、表示欄が横伸びしてしまう
 export const StyledSchedule = styled.div<StyleProps>`
   width: ${(props) => props.width || '100%'};
   background-color: ${(props) =>
@@ -26,4 +25,5 @@ export const StyledSchedule = styled.div<StyleProps>`
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  word-break: break-all;
 `;


### PR DESCRIPTION
# 概要
バグ修正
Issue: https://github.com/PenPeen/react_calendar_app/issues/42

タイトルに数値のみ入力された場合に表示が間延びしてしまっていたので修正した。

## Before
![image](https://github.com/PenPeen/react_calendar_app/assets/87213337/0242a42f-0dc5-4a35-8c00-e3761bd2a042)

## After
![image](https://github.com/PenPeen/react_calendar_app/assets/87213337/e7e55fb3-65f0-4880-9d90-1dcf12d52528)
